### PR TITLE
Specified YAML Loader to BaseLoader.

### DIFF
--- a/pyannote/pipeline/experiment.py
+++ b/pyannote/pipeline/experiment.py
@@ -161,7 +161,7 @@ class Experiment:
         # load configuration file
         config_yml = self.CONFIG_YML.format(experiment_dir=self.experiment_dir)
         with open(config_yml, 'r') as fp:
-            self.config_ = yaml.load(fp)
+            self.config_ = yaml.load(fp, Loader=yaml.BaseLoader)
 
         # initialize preprocessors
         preprocessors = {}

--- a/pyannote/pipeline/pipeline.py
+++ b/pyannote/pipeline/pipeline.py
@@ -451,7 +451,7 @@ class Pipeline:
         """
 
         with open(params_yml, mode='r') as fp:
-            params = yaml.load(fp)
+            params = yaml.load(fp, Loader=yaml.BaseLoader)
         return self.instantiate(params)
 
     def __call__(self, input: PipelineInput) -> PipelineOutput:


### PR DESCRIPTION
Due to security issues with the `yaml.load` function, a `Loader` must be specified.
I chose `yaml.BaseLoader` which only parses basic python objects such as dictionnaries, lists and strings. `config.yml` files in pyannote does not need more but it could be replaced easily by another Loader if needed.
See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation for more details.