### PR TITLE
Changed YAML Loader to yaml.SafeLoader.

### DIFF
--- a/pyannote/pipeline/experiment.py
+++ b/pyannote/pipeline/experiment.py
@@ -161,7 +161,7 @@ class Experiment:
         # load configuration file
         config_yml = self.CONFIG_YML.format(experiment_dir=self.experiment_dir)
         with open(config_yml, 'r') as fp:
-            self.config_ = yaml.load(fp)
+            self.config_ = yaml.load(fp, Loader=yaml.SafeLoader)
 
         # initialize preprocessors
         preprocessors = {}

--- a/pyannote/pipeline/pipeline.py
+++ b/pyannote/pipeline/pipeline.py
@@ -451,7 +451,7 @@ class Pipeline:
         """
 
         with open(params_yml, mode='r') as fp:
-            params = yaml.load(fp)
+            params = yaml.load(fp, Loader=yaml.SafeLoader)
         return self.instantiate(params)
 
     def __call__(self, input: PipelineInput) -> PipelineOutput:


### PR DESCRIPTION
Due to security issues when using the yaml.load function, the attribute Loader has to be set to a secure loader. Several are available and we chose yaml.SafeLoader.
For more information, see https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation.