### PR TITLE
feat: ClosestAssignment now handles multi-sample references

### DIFF
--- a/pyannote/pipeline/blocks/classification.py
+++ b/pyannote/pipeline/blocks/classification.py
@@ -120,11 +120,10 @@ class ClosestAssignment(Pipeline):
                 else:
                     raise ValueError(f"{method} is an invalid value for method, see \n{help(classifier)}")
                 distances.append(distance)
-        targets = np.argmin(distances, axis=0)
+        target = np.argmin(distances, axis=0)
 
-        # for i, k in enumerate(targets):
-        #     if distances[k, i] > self.threshold:
-        #         # do not assign
-        #         targets[i] = -i
+        if distances[target] > self.threshold:
+            # do not assign
+            target = -1
 
-        return targets
+        return target


### PR DESCRIPTION
Beware that the behaviour changed a bit : now we assign only one target for the whole n_samples of X (I can change that if you want to but I don't see the point).
Also I don't know if you like that I check `isinstance(X_target,np.ndarray)` to know whether the target has one or several samples 