### PR TITLE
Add seed param to optimizer init

### DIFF
--- a/pyannote/pipeline/optimizer.py
+++ b/pyannote/pipeline/optimizer.py
@@ -68,6 +68,9 @@ class Optimizer:
         Algorithm for early pruning of trials. Must be one of "MedianPruner" or
         "SuccessiveHalvingPruner", or a pruner instance.
         Defaults to no pruning.
+    seed : `int`, optional
+        Seed value for the random number generator of the sampler. 
+        Defaults to no seed.
     """
 
     def __init__(
@@ -77,6 +80,7 @@ class Optimizer:
         study_name: Optional[str] = None,
         sampler: Optional[Union[str, BaseSampler]] = None,
         pruner: Optional[Union[str, BasePruner]] = None,
+        seed: Optional[int] = None,
     ):
 
         self.pipeline = pipeline
@@ -92,12 +96,12 @@ class Optimizer:
             self.sampler = sampler
         elif isinstance(sampler, str):
             try:
-                self.sampler = getattr(optuna.samplers, sampler)()
+                self.sampler = getattr(optuna.samplers, sampler)(seed=seed)
             except AttributeError as e:
                 msg = '`sampler` must be one of "RandomSampler" or "TPESampler"'
                 raise ValueError(msg)
         elif sampler is None:
-            self.sampler = TPESampler()
+            self.sampler = TPESampler(seed=seed)
 
         if isinstance(pruner, BasePruner):
             self.pruner = pruner


### PR DESCRIPTION
This PR adds an optional `seed` argument to the Optimizer's `__init__`, in order to allow for reproducibility between runs.

The value is passed directly to the Optuna sampler constructed when the `sampler` argument is a string, or when it is `None`. The default seed value of `None` is safe to pass both samplers ([RandomSampler](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.RandomSampler.html) and [TPESampler](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.TPESampler.html#optuna.samplers.TPESampler)) as they both have a `seed` argument, and already default it to `None`.

The seed is not passed if a Sampler instance is passed directly, as the `seed` argument is not in the [ABC](optuna.readthedocs.io/en/stable/reference/generated/optuna.samplers.BaseSampler.html), and indeed not present in some samplers like GridSampler.

I considered adding a line about reproducibility to the docstring but kept it short like the other argument descriptions, assuming that a `seed` argument already implies a random seed, which in turn implies variation in output if not passed.