### PR TITLE
added scipy import back #51

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 #########
 
+develop
+~~~~~~~~
+
+- fix: fix missing `scipy` import (#54, @arxaqapi)
+
 Version 3.0.1 (2023-09-22)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyannote/pipeline/optimizer.py
+++ b/pyannote/pipeline/optimizer.py
@@ -43,6 +43,7 @@ from optuna.trial import Trial, FixedTrial
 from optuna.storages import RDBStorage, JournalStorage, JournalFileStorage
 from tqdm import tqdm
 from optuna.storages import RDBStorage, JournalStorage, JournalFileStorage
+from scipy.stats import bayes_mvs
 
 from .pipeline import Pipeline
 from .typing import PipelineInput


### PR DESCRIPTION
Simply added the missing import back to [optimizer.py#L46](https://github.com/arxaqapi/pyannote-pipeline/blob/fix_scipy_stats/pyannote/pipeline/optimizer.py#L46).